### PR TITLE
Add live update support to the track builder

### DIFF
--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -2,6 +2,7 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Splines;
+using Unity.Mathematics;
 using System.Collections.Generic;
 
 public class TrackWindowEditor : EditorWindow
@@ -15,16 +16,31 @@ public class TrackWindowEditor : EditorWindow
     float startOffset = 0f;
     float endOffset = 0f;
     bool alignToTangent = true;
+    bool liveUpdate = false;
 
-    int lengthSteps = 512; 
-    int mapSteps = 2048;    
+    int lengthSteps = 512;
+    int mapSteps = 2048;
 
 
-   
+
     Vector2 scroll;
+
+    BuildSettings lastSettings;
+    int lastSplineHash;
+    bool hasGenerated;
 
     [MenuItem("Tools/RaceTrack Builder")]
     public static void Open() => GetWindow<TrackWindowEditor>("RaceTrack Builder").Show();
+
+    void OnEnable()
+    {
+        EditorApplication.update += OnEditorUpdate;
+    }
+
+    void OnDisable()
+    {
+        EditorApplication.update -= OnEditorUpdate;
+    }
 
     void OnGUI()
     {
@@ -41,6 +57,7 @@ public class TrackWindowEditor : EditorWindow
         startOffset = Mathf.Max(0f, EditorGUILayout.FloatField("Start Offset (m)", startOffset));
         endOffset = Mathf.Max(0f, EditorGUILayout.FloatField("End Offset (m)", endOffset));
         alignToTangent = EditorGUILayout.Toggle("Align to Tangent", alignToTangent);
+        liveUpdate = EditorGUILayout.ToggleLeft("Live Update", liveUpdate);
 
         EditorGUILayout.Space();
         EditorGUILayout.LabelField("Quality", EditorStyles.boldLabel);
@@ -52,11 +69,22 @@ public class TrackWindowEditor : EditorWindow
         {
             GUI.enabled = (spline != null && prefab != null);
             if (GUILayout.Button("Generate", GUILayout.Height(32)))
-                Generate();
+            {
+                if (Generate(recordUndo: true))
+                {
+                    UpdateLastSettings();
+                    hasGenerated = true;
+                }
+            }
 
             GUI.enabled = (parent != null);
             if (GUILayout.Button("Clear Parent Children", GUILayout.Height(32)))
+            {
                 ClearParentChildren();
+                hasGenerated = false;
+                lastSettings = default;
+                lastSplineHash = 0;
+            }
             GUI.enabled = true;
         }
 
@@ -66,67 +94,48 @@ public class TrackWindowEditor : EditorWindow
             MessageType.Info);
 
         EditorGUILayout.EndScrollView();
+
+        if (liveUpdate)
+            TryLiveUpdate();
     }
 
-    void Generate()
+    void OnEditorUpdate()
+    {
+        if (liveUpdate)
+            TryLiveUpdate();
+    }
+
+    bool Generate(bool recordUndo)
     {
         if (spline == null || prefab == null)
         {
-            // I would like build this out to be something that will tell the user this issue and not to console 
-            // this is a note for all Debug Warnings.
-
             Debug.LogWarning("Assign a Spline and a Prefab.");
-            return;
+            return false;
         }
 
         var s = spline.Spline;
-        if (s == null || s.Count < 2) { Debug.LogWarning("Spline is empty."); return; }
+        if (s == null || s.Count < 2)
+        {
+            Debug.LogWarning("Spline is empty.");
+            return false;
+        }
 
         if (parent == null)
         {
             var holder = new GameObject("PrefabBuilt_");
+            Undo.RegisterCreatedObjectUndo(holder, "Create Track Parent");
             parent = holder.transform;
         }
 
-        // Wrap in Undo and mark dirty
-        EditorUtil.WithUndo(parent, "Generate Along Spline", () =>
-        {
-            float totalLen = ApproximateLength(s, lengthSteps);
-            float usable = Mathf.Max(0f, totalLen - startOffset - endOffset);
-            if (usable <= 0.01f) return;
+        var placements = BuildPlacements(s);
+        System.Action apply = () => ApplyPlacements(placements);
 
-            var world = spline.transform.localToWorldMatrix;
+        if (recordUndo)
+            EditorUtil.WithUndo(parent, "Generate Along Spline", apply);
+        else
+            EditorUtil.WithSceneDirty(apply);
 
-            for (float d = 0f; d <= usable; d += spacing)
-            {
-                float t = DistanceToT(s, startOffset + d, mapSteps);
-
-
-            
-                var posLocal = (Vector3)s.EvaluatePosition(t);
-                var tanLocal = ((Vector3)s.EvaluateTangent(t)).normalized;
-                var upLocal = ((Vector3)s.EvaluateUpVector(t)).normalized;
-                if (upLocal.sqrMagnitude < 1e-4f) upLocal = Vector3.up;
-
-                // to world
-                Vector3 pos = world.MultiplyPoint3x4(posLocal);
-                Vector3 tan = world.MultiplyVector(tanLocal).normalized;
-                Vector3 up = world.MultiplyVector(upLocal).normalized;
-
-
-
-                var rot = Quaternion.LookRotation(tan, up);
-
-
-                var go = EditorUtil.InstantiatePrefab(prefab, parent);
-                go.name = $"Piece_{parent.childCount:000}";
-
-                if (alignToTangent)
-                    go.transform.SetPositionAndRotation(pos, Quaternion.LookRotation(tan, up));
-                else
-                    go.transform.position = pos;
-            }
-        });
+        return true;
     }
 
     void ClearParentChildren()
@@ -138,11 +147,29 @@ public class TrackWindowEditor : EditorWindow
             foreach (Transform c in parent) toDelete.Add(c.gameObject);
 
             foreach (var go in toDelete)
-            {
-                if (!Application.isPlaying) DestroyImmediate(go);
-                else Destroy(go);
-            }
+                EditorUtil.DestroyObject(go);
         });
+    }
+
+    void TryLiveUpdate()
+    {
+        var settings = CaptureSettings();
+        if (!settings.IsValid || spline == null)
+        {
+            hasGenerated = false;
+            return;
+        }
+
+        int splineHash = ComputeSplineHash(spline.Spline);
+        if (!hasGenerated || !settings.Equals(lastSettings) || splineHash != lastSplineHash)
+        {
+            if (Generate(recordUndo: false))
+            {
+                lastSettings = settings;
+                lastSplineHash = splineHash;
+                hasGenerated = true;
+            }
+        }
     }
 
     float ApproximateLength(Spline s, int steps)
@@ -184,6 +211,200 @@ public class TrackWindowEditor : EditorWindow
         }
         return 1f;
     }
+
+    List<PlacementData> BuildPlacements(Spline s)
+    {
+        var placements = new List<PlacementData>();
+
+        float totalLen = ApproximateLength(s, lengthSteps);
+        if (totalLen <= 1e-4f)
+            return placements;
+
+        float usableStart = Mathf.Clamp(startOffset, 0f, totalLen);
+        float usableEnd = Mathf.Clamp(totalLen - endOffset, 0f, totalLen);
+        if (usableEnd < usableStart)
+            usableEnd = usableStart;
+
+        float usableLength = usableEnd - usableStart;
+        if (usableLength <= 0.01f)
+        {
+            float distance = Mathf.Clamp(usableStart, 0f, totalLen);
+            placements.Add(CreatePlacement(s, distance));
+            return placements;
+        }
+
+        int steps = Mathf.Max(1, Mathf.FloorToInt(usableLength / spacing) + 1);
+
+        for (int i = 0; i < steps; i++)
+        {
+            float distance = Mathf.Min(usableStart + i * spacing, usableEnd);
+            placements.Add(CreatePlacement(s, distance));
+        }
+
+        return placements;
+    }
+
+    PlacementData CreatePlacement(Spline s, float distance)
+    {
+        float t = DistanceToT(s, distance, mapSteps);
+
+        var posLocal = (Vector3)s.EvaluatePosition(t);
+        var tanLocal = ((Vector3)s.EvaluateTangent(t)).normalized;
+        var upLocal = ((Vector3)s.EvaluateUpVector(t)).normalized;
+        if (upLocal.sqrMagnitude < 1e-4f) upLocal = Vector3.up;
+
+        var world = spline.transform.localToWorldMatrix;
+        Vector3 pos = world.MultiplyPoint3x4(posLocal);
+        Vector3 tan = world.MultiplyVector(tanLocal).normalized;
+        Vector3 up = world.MultiplyVector(upLocal).normalized;
+
+        return new PlacementData
+        {
+            position = pos,
+            rotation = Quaternion.LookRotation(tan, up)
+        };
+    }
+
+    void ApplyPlacements(List<PlacementData> placements)
+    {
+        var existing = new List<Transform>();
+        for (int i = 0; i < parent.childCount; i++)
+            existing.Add(parent.GetChild(i));
+
+        int count = placements.Count;
+        for (int i = 0; i < count; i++)
+        {
+            var placement = placements[i];
+            Transform child;
+
+            if (i < existing.Count)
+            {
+                child = existing[i];
+            }
+            else
+            {
+                var go = EditorUtil.InstantiatePrefab(prefab, parent);
+                child = go.transform;
+            }
+
+            child.gameObject.name = $"Piece_{i:000}";
+
+            if (alignToTangent)
+                child.SetPositionAndRotation(placement.position, placement.rotation);
+            else
+                child.position = placement.position;
+        }
+
+        for (int i = count; i < existing.Count; i++)
+            EditorUtil.DestroyObject(existing[i].gameObject);
+    }
+
+    void UpdateLastSettings()
+    {
+        lastSettings = CaptureSettings();
+        lastSplineHash = spline != null ? ComputeSplineHash(spline.Spline) : 0;
+    }
+
+    BuildSettings CaptureSettings()
+    {
+        return new BuildSettings
+        {
+            splineId = spline != null ? spline.GetInstanceID() : 0,
+            prefabId = prefab != null ? prefab.GetInstanceID() : 0,
+            parentId = parent != null ? parent.GetInstanceID() : 0,
+            spacing = this.spacing,
+            startOffset = this.startOffset,
+            endOffset = this.endOffset,
+            alignToTangent = this.alignToTangent,
+            lengthSteps = this.lengthSteps,
+            mapSteps = this.mapSteps
+        };
+    }
+
+    int ComputeSplineHash(Spline s)
+    {
+        if (s == null)
+            return 0;
+
+        unchecked
+        {
+            int hash = s.Count;
+            for (int i = 0; i < s.Count; i++)
+            {
+                var knot = s[i];
+                hash = hash * 31 + HashFloat3(knot.Position);
+                hash = hash * 31 + HashFloat3(knot.TangentIn);
+                hash = hash * 31 + HashFloat3(knot.TangentOut);
+                hash = hash * 31 + knot.Rotation.GetHashCode();
+            }
+            return hash;
+        }
+    }
+
+    static int HashFloat3(float3 value)
+    {
+        unchecked
+        {
+            int hash = 17;
+            hash = hash * 23 + value.x.GetHashCode();
+            hash = hash * 23 + value.y.GetHashCode();
+            hash = hash * 23 + value.z.GetHashCode();
+            return hash;
+        }
+    }
+
+    struct PlacementData
+    {
+        public Vector3 position;
+        public Quaternion rotation;
+    }
+
+    struct BuildSettings
+    {
+        public int splineId;
+        public int prefabId;
+        public int parentId;
+        public float spacing;
+        public float startOffset;
+        public float endOffset;
+        public bool alignToTangent;
+        public int lengthSteps;
+        public int mapSteps;
+
+        public bool IsValid => splineId != 0 && prefabId != 0;
+
+        public bool Equals(BuildSettings other)
+        {
+            return splineId == other.splineId &&
+                   prefabId == other.prefabId &&
+                   parentId == other.parentId &&
+                   Mathf.Approximately(spacing, other.spacing) &&
+                   Mathf.Approximately(startOffset, other.startOffset) &&
+                   Mathf.Approximately(endOffset, other.endOffset) &&
+                   alignToTangent == other.alignToTangent &&
+                   lengthSteps == other.lengthSteps &&
+                   mapSteps == other.mapSteps;
+        }
+
+        public override bool Equals(object obj) => obj is BuildSettings other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = splineId;
+                hash = hash * 31 + prefabId;
+                hash = hash * 31 + parentId;
+                hash = hash * 31 + Mathf.RoundToInt(spacing * 1000f);
+                hash = hash * 31 + Mathf.RoundToInt(startOffset * 1000f);
+                hash = hash * 31 + Mathf.RoundToInt(endOffset * 1000f);
+                hash = hash * 31 + (alignToTangent ? 1 : 0);
+                hash = hash * 31 + lengthSteps;
+                hash = hash * 31 + mapSteps;
+                return hash;
+            }
+        }
+    }
 }
 static class EditorUtil
 {
@@ -198,10 +419,30 @@ static class EditorUtil
         }
     }
 
+    public static void WithSceneDirty(System.Action act)
+    {
+        try { act?.Invoke(); }
+        finally
+        {
+            var scene = EditorSceneManager.GetActiveScene();
+            if (scene.IsValid()) EditorSceneManager.MarkSceneDirty(scene);
+        }
+    }
+
     public static GameObject InstantiatePrefab(GameObject prefab, Transform parent = null)
     {
         var go = PrefabUtility.InstantiatePrefab(prefab, parent) as GameObject;
         if (go == null) go = Object.Instantiate(prefab, parent);
         return go;
+    }
+
+    public static void DestroyObject(GameObject go)
+    {
+        if (go == null) return;
+
+        if (!Application.isPlaying)
+            Object.DestroyImmediate(go);
+        else
+            Object.Destroy(go);
     }
 }

--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -224,24 +224,18 @@ public class TrackWindowEditor : EditorWindow
         if (usableEnd < usableStart)
             usableEnd = usableStart;
 
-        float usableLength = usableEnd - usableStart;
-        float minSingleLength = Mathf.Max(0.01f, spacing * 0.25f);
-        if (usableLength <= minSingleLength)
-        {
-            float singleDistance = Mathf.Clamp(usableStart, 0f, totalLen);
-            placements.Add(CreatePlacement(s, singleDistance));
-            return placements;
-        }
+        float step = Mathf.Max(0.01f, spacing);
+        int maxPlacements = Mathf.Clamp(Mathf.CeilToInt((usableEnd - usableStart) / step) + 2, 1, 100000);
 
-        int segmentCount = Mathf.Max(1, Mathf.RoundToInt(usableLength / spacing));
-        int placementCount = Mathf.Clamp(segmentCount + 1, 2, 100000);
-
-        for (int i = 0; i < placementCount; i++)
+        float distance = usableStart;
+        for (int i = 0; i < maxPlacements && distance <= usableEnd + 1e-3f; i++)
         {
-            float t = placementCount > 1 ? i / (float)(placementCount - 1) : 0f;
-            float distance = Mathf.Lerp(usableStart, usableEnd, t);
             placements.Add(CreatePlacement(s, distance));
+            distance += step;
         }
+
+        if (placements.Count == 0)
+            placements.Add(CreatePlacement(s, usableStart));
 
         return placements;
     }

--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -17,6 +17,7 @@ public class TrackWindowEditor : EditorWindow
     bool alignToTangent = true;
     bool snapSpacingToPrefab = true;
     bool liveUpdate = false;
+    bool stretchToEnd = false;
 
     int lengthSteps = 512;
     int mapSteps = 2048;
@@ -80,6 +81,7 @@ public class TrackWindowEditor : EditorWindow
         startOffset = Mathf.Max(0f, EditorGUILayout.FloatField("Start Offset (m)", startOffset));
         endOffset = Mathf.Max(0f, EditorGUILayout.FloatField("End Offset (m)", endOffset));
         alignToTangent = EditorGUILayout.Toggle("Align to Tangent", alignToTangent);
+        stretchToEnd = EditorGUILayout.ToggleLeft("Stretch Last Segment To End", stretchToEnd);
         liveUpdate = EditorGUILayout.ToggleLeft("Live Update", liveUpdate);
 
         EditorGUILayout.Space();
@@ -378,7 +380,7 @@ public class TrackWindowEditor : EditorWindow
         {
             contacts.Add(usableStart);
         }
-        else
+        else if (stretchToEnd)
         {
             float lastContact = contacts[contacts.Count - 1];
             if (maxContact - lastContact > 1e-3f && contacts.Count < MaxPlacements)
@@ -475,6 +477,7 @@ public class TrackWindowEditor : EditorWindow
             endOffset = this.endOffset,
             alignToTangent = this.alignToTangent,
             snapSpacingToPrefab = this.snapSpacingToPrefab,
+            stretchToEnd = this.stretchToEnd,
             lengthSteps = this.lengthSteps,
             mapSteps = this.mapSteps
         };
@@ -536,6 +539,7 @@ public class TrackWindowEditor : EditorWindow
         public float endOffset;
         public bool alignToTangent;
         public bool snapSpacingToPrefab;
+        public bool stretchToEnd;
         public int lengthSteps;
         public int mapSteps;
 
@@ -551,6 +555,7 @@ public class TrackWindowEditor : EditorWindow
                    Mathf.Approximately(endOffset, other.endOffset) &&
                    alignToTangent == other.alignToTangent &&
                    snapSpacingToPrefab == other.snapSpacingToPrefab &&
+                   stretchToEnd == other.stretchToEnd &&
                    lengthSteps == other.lengthSteps &&
                    mapSteps == other.mapSteps;
         }
@@ -569,6 +574,7 @@ public class TrackWindowEditor : EditorWindow
                 hash = hash * 31 + Mathf.RoundToInt(endOffset * 1000f);
                 hash = hash * 31 + (alignToTangent ? 1 : 0);
                 hash = hash * 31 + (snapSpacingToPrefab ? 1 : 0);
+                hash = hash * 31 + (stretchToEnd ? 1 : 0);
                 hash = hash * 31 + lengthSteps;
                 hash = hash * 31 + mapSteps;
                 return hash;

--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -2,7 +2,6 @@ using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Splines;
-using Unity.Mathematics;
 using System.Collections.Generic;
 
 public class TrackWindowEditor : EditorWindow
@@ -128,7 +127,7 @@ public class TrackWindowEditor : EditorWindow
         }
 
         var placements = BuildPlacements(s);
-        System.Action apply = () => ApplyPlacements(placements);
+        System.Action apply = () => ApplyPlacements(placements, recordUndo);
 
         if (recordUndo)
             EditorUtil.WithUndo(parent, "Generate Along Spline", apply);
@@ -268,7 +267,7 @@ public class TrackWindowEditor : EditorWindow
         };
     }
 
-    void ApplyPlacements(List<PlacementData> placements)
+    void ApplyPlacements(List<PlacementData> placements, bool recordUndo)
     {
         var existing = new List<Transform>();
         for (int i = 0; i < parent.childCount; i++)
@@ -287,6 +286,8 @@ public class TrackWindowEditor : EditorWindow
             else
             {
                 var go = EditorUtil.InstantiatePrefab(prefab, parent);
+                if (recordUndo)
+                    Undo.RegisterCreatedObjectUndo(go, "Create Track Piece");
                 child = go.transform;
             }
 
@@ -332,26 +333,25 @@ public class TrackWindowEditor : EditorWindow
         unchecked
         {
             int hash = s.Count;
-            for (int i = 0; i < s.Count; i++)
+            int samples = Mathf.Clamp(s.Count * 8, 16, 256);
+            for (int i = 0; i <= samples; i++)
             {
-                var knot = s[i];
-                hash = hash * 31 + HashFloat3(knot.Position);
-                hash = hash * 31 + HashFloat3(knot.TangentIn);
-                hash = hash * 31 + HashFloat3(knot.TangentOut);
-                hash = hash * 31 + knot.Rotation.GetHashCode();
+                float t = samples > 0 ? i / (float)samples : 0f;
+                hash = hash * 31 + HashVector3(s.EvaluatePosition(t));
+                hash = hash * 31 + HashVector3(s.EvaluateTangent(t));
             }
             return hash;
         }
     }
 
-    static int HashFloat3(float3 value)
+    static int HashVector3(Vector3 value)
     {
         unchecked
         {
             int hash = 17;
-            hash = hash * 23 + value.x.GetHashCode();
-            hash = hash * 23 + value.y.GetHashCode();
-            hash = hash * 23 + value.z.GetHashCode();
+            hash = hash * 23 + Mathf.RoundToInt(value.x * 1000f);
+            hash = hash * 23 + Mathf.RoundToInt(value.y * 1000f);
+            hash = hash * 23 + Mathf.RoundToInt(value.z * 1000f);
             return hash;
         }
     }
@@ -413,7 +413,7 @@ static class EditorUtil
 {
     public static void WithUndo(Object targetRoot, string label, System.Action act)
     {
-        Undo.RegisterFullObjectHierarchyUndo(targetRoot, label);
+        RegisterUndoHierarchy(targetRoot, label);
         try { act?.Invoke(); }
         finally
         {
@@ -447,5 +447,35 @@ static class EditorUtil
             Object.DestroyImmediate(go);
         else
             Object.Destroy(go);
+    }
+
+    static void RegisterUndoHierarchy(Object targetRoot, string label)
+    {
+#if UNITY_2021_2_OR_NEWER
+        Undo.RegisterFullObjectHierarchyUndo(targetRoot, label);
+#else
+        if (targetRoot == null)
+            return;
+
+        if (targetRoot is GameObject go)
+        {
+            Undo.RegisterCompleteObjectUndo(go, label);
+            if (go.transform != null)
+                Undo.RegisterCompleteObjectUndo(go.transform, label);
+            foreach (Transform child in go.transform)
+                RegisterUndoHierarchy(child.gameObject, label);
+        }
+        else if (targetRoot is Transform tf)
+        {
+            Undo.RegisterCompleteObjectUndo(tf, label);
+            Undo.RegisterCompleteObjectUndo(tf.gameObject, label);
+            foreach (Transform child in tf)
+                RegisterUndoHierarchy(child.gameObject, label);
+        }
+        else
+        {
+            Undo.RegisterCompleteObjectUndo(targetRoot, label);
+        }
+#endif
     }
 }

--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -15,6 +15,7 @@ public class TrackWindowEditor : EditorWindow
     float startOffset = 0f;
     float endOffset = 0f;
     bool alignToTangent = true;
+    bool snapSpacingToPrefab = true;
     bool liveUpdate = false;
 
     int lengthSteps = 512;
@@ -52,7 +53,30 @@ public class TrackWindowEditor : EditorWindow
 
         EditorGUILayout.Space();
         EditorGUILayout.LabelField("Placement", EditorStyles.boldLabel);
-        spacing = Mathf.Max(0.01f, EditorGUILayout.FloatField("Spacing (m)", spacing));
+        var prefabBounds = CalculatePrefabBounds(prefab);
+        snapSpacingToPrefab = EditorGUILayout.ToggleLeft("Snap Spacing To Prefab Length", snapSpacingToPrefab);
+
+        bool usingAutomaticSpacing = snapSpacingToPrefab && prefabBounds.IsValid;
+        float spacingFieldValue = usingAutomaticSpacing ? Mathf.Max(0.01f, prefabBounds.Length) : spacing;
+
+        using (new EditorGUI.DisabledScope(usingAutomaticSpacing))
+        {
+            spacingFieldValue = EditorGUILayout.FloatField("Spacing (m)", spacingFieldValue);
+        }
+
+        if (usingAutomaticSpacing)
+        {
+            EditorGUILayout.LabelField($"Prefab length: {prefabBounds.Length:F3} m", EditorStyles.miniLabel);
+        }
+        else
+        {
+            spacing = Mathf.Max(0.01f, spacingFieldValue);
+        }
+
+        if (snapSpacingToPrefab && !prefabBounds.IsValid && prefab != null)
+        {
+            EditorGUILayout.HelpBox("Prefab bounds not found; manual spacing will be used.", MessageType.Info);
+        }
         startOffset = Mathf.Max(0f, EditorGUILayout.FloatField("Start Offset (m)", startOffset));
         endOffset = Mathf.Max(0f, EditorGUILayout.FloatField("End Offset (m)", endOffset));
         alignToTangent = EditorGUILayout.Toggle("Align to Tangent", alignToTangent);
@@ -211,6 +235,115 @@ public class TrackWindowEditor : EditorWindow
         return 1f;
     }
 
+    PrefabBoundsInfo CalculatePrefabBounds(GameObject targetPrefab)
+    {
+        PrefabBoundsInfo result = default;
+        if (targetPrefab == null)
+            return result;
+
+        var root = targetPrefab.transform;
+        Matrix4x4 rootWorldToLocal = root.worldToLocalMatrix;
+        float minZ = float.PositiveInfinity;
+        float maxZ = float.NegativeInfinity;
+        bool hasBounds = false;
+
+        var meshFilters = targetPrefab.GetComponentsInChildren<MeshFilter>(true);
+        foreach (var filter in meshFilters)
+        {
+            var mesh = filter.sharedMesh;
+            if (mesh == null)
+                continue;
+
+            Matrix4x4 meshToRoot = rootWorldToLocal * filter.transform.localToWorldMatrix;
+            ExpandBounds(ref minZ, ref maxZ, meshToRoot, mesh.bounds);
+            hasBounds = true;
+        }
+
+        var skinnedMeshes = targetPrefab.GetComponentsInChildren<SkinnedMeshRenderer>(true);
+        foreach (var skinned in skinnedMeshes)
+        {
+            var mesh = skinned.sharedMesh;
+            if (mesh == null)
+                continue;
+
+            Matrix4x4 meshToRoot = rootWorldToLocal * skinned.transform.localToWorldMatrix;
+            ExpandBounds(ref minZ, ref maxZ, meshToRoot, mesh.bounds);
+            hasBounds = true;
+        }
+
+        var colliders = targetPrefab.GetComponentsInChildren<Collider>(true);
+        foreach (var collider in colliders)
+        {
+            Bounds localBounds;
+            if (collider is BoxCollider box)
+            {
+                localBounds = new Bounds(box.center, box.size);
+            }
+            else if (collider is SphereCollider sphere)
+            {
+                float diameter = sphere.radius * 2f;
+                localBounds = new Bounds(sphere.center, new Vector3(diameter, diameter, diameter));
+            }
+            else if (collider is CapsuleCollider capsule)
+            {
+                Vector3 size = Vector3.one * (capsule.radius * 2f);
+                switch (capsule.direction)
+                {
+                    case 0: size.x = capsule.height; break;
+                    case 1: size.y = capsule.height; break;
+                    default: size.z = capsule.height; break;
+                }
+                localBounds = new Bounds(capsule.center, size);
+            }
+            else if (collider is MeshCollider meshCollider && meshCollider.sharedMesh != null)
+            {
+                localBounds = meshCollider.sharedMesh.bounds;
+            }
+            else
+            {
+                continue;
+            }
+
+            Matrix4x4 colliderToRoot = rootWorldToLocal * collider.transform.localToWorldMatrix;
+            ExpandBounds(ref minZ, ref maxZ, colliderToRoot, localBounds);
+            hasBounds = true;
+        }
+
+        if (!hasBounds || float.IsNaN(minZ) || float.IsNaN(maxZ) || float.IsInfinity(minZ) || float.IsInfinity(maxZ))
+            return result;
+
+        if (minZ > maxZ)
+        {
+            float temp = minZ;
+            minZ = maxZ;
+            maxZ = temp;
+        }
+
+        result.IsValid = true;
+        result.MinZ = minZ;
+        result.MaxZ = maxZ;
+        return result;
+    }
+
+    static void ExpandBounds(ref float minZ, ref float maxZ, Matrix4x4 localToRoot, Bounds localBounds)
+    {
+        Vector3 center = localBounds.center;
+        Vector3 extents = localBounds.extents;
+
+        for (int i = 0; i < 8; i++)
+        {
+            Vector3 corner = center;
+            corner.x += ((i & 1) == 0) ? -extents.x : extents.x;
+            corner.y += ((i & 2) == 0) ? -extents.y : extents.y;
+            corner.z += ((i & 4) == 0) ? -extents.z : extents.z;
+
+            Vector3 rootSpace = localToRoot.MultiplyPoint3x4(corner);
+            float z = rootSpace.z;
+            if (z < minZ) minZ = z;
+            if (z > maxZ) maxZ = z;
+        }
+    }
+
     List<PlacementData> BuildPlacements(Spline s)
     {
         var placements = new List<PlacementData>();
@@ -224,18 +357,45 @@ public class TrackWindowEditor : EditorWindow
         if (usableEnd < usableStart)
             usableEnd = usableStart;
 
-        float step = Mathf.Max(0.01f, spacing);
-        int maxPlacements = Mathf.Clamp(Mathf.CeilToInt((usableEnd - usableStart) / step) + 2, 1, 100000);
+        var bounds = CalculatePrefabBounds(prefab);
+        float step = Mathf.Max(0.01f, snapSpacingToPrefab && bounds.IsValid ? bounds.Length : spacing);
+        float pivotBackOffset = bounds.IsValid ? -bounds.MinZ : 0f;
+        float segmentLength = bounds.IsValid ? Mathf.Max(0.01f, bounds.Length) : step;
 
-        float distance = usableStart;
-        for (int i = 0; i < maxPlacements && distance <= usableEnd + 1e-3f; i++)
+        float maxContact = Mathf.Max(usableStart, usableEnd - segmentLength);
+        const int MaxPlacements = 100000;
+        var contacts = new List<float>();
+
+        float contact = usableStart;
+        int guard = 0;
+        while (contact <= maxContact + 1e-3f && guard++ < MaxPlacements)
         {
-            placements.Add(CreatePlacement(s, distance));
-            distance += step;
+            contacts.Add(contact);
+            contact += step;
         }
 
-        if (placements.Count == 0)
-            placements.Add(CreatePlacement(s, usableStart));
+        if (contacts.Count == 0)
+        {
+            contacts.Add(usableStart);
+        }
+        else
+        {
+            float lastContact = contacts[contacts.Count - 1];
+            if (maxContact - lastContact > 1e-3f && contacts.Count < MaxPlacements)
+            {
+                contacts.Add(maxContact);
+            }
+            else
+            {
+                contacts[contacts.Count - 1] = maxContact;
+            }
+        }
+
+        foreach (var contactDistance in contacts)
+        {
+            float pivotDistance = Mathf.Clamp(contactDistance + pivotBackOffset, 0f, totalLen);
+            placements.Add(CreatePlacement(s, pivotDistance));
+        }
 
         return placements;
     }
@@ -314,6 +474,7 @@ public class TrackWindowEditor : EditorWindow
             startOffset = this.startOffset,
             endOffset = this.endOffset,
             alignToTangent = this.alignToTangent,
+            snapSpacingToPrefab = this.snapSpacingToPrefab,
             lengthSteps = this.lengthSteps,
             mapSteps = this.mapSteps
         };
@@ -356,6 +517,15 @@ public class TrackWindowEditor : EditorWindow
         public Quaternion rotation;
     }
 
+    struct PrefabBoundsInfo
+    {
+        public bool IsValid;
+        public float MinZ;
+        public float MaxZ;
+
+        public float Length => MaxZ - MinZ;
+    }
+
     struct BuildSettings
     {
         public int splineId;
@@ -365,6 +535,7 @@ public class TrackWindowEditor : EditorWindow
         public float startOffset;
         public float endOffset;
         public bool alignToTangent;
+        public bool snapSpacingToPrefab;
         public int lengthSteps;
         public int mapSteps;
 
@@ -379,6 +550,7 @@ public class TrackWindowEditor : EditorWindow
                    Mathf.Approximately(startOffset, other.startOffset) &&
                    Mathf.Approximately(endOffset, other.endOffset) &&
                    alignToTangent == other.alignToTangent &&
+                   snapSpacingToPrefab == other.snapSpacingToPrefab &&
                    lengthSteps == other.lengthSteps &&
                    mapSteps == other.mapSteps;
         }
@@ -396,6 +568,7 @@ public class TrackWindowEditor : EditorWindow
                 hash = hash * 31 + Mathf.RoundToInt(startOffset * 1000f);
                 hash = hash * 31 + Mathf.RoundToInt(endOffset * 1000f);
                 hash = hash * 31 + (alignToTangent ? 1 : 0);
+                hash = hash * 31 + (snapSpacingToPrefab ? 1 : 0);
                 hash = hash * 31 + lengthSteps;
                 hash = hash * 31 + mapSteps;
                 return hash;

--- a/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
+++ b/Assets/Scripts/TrackBuilderEditor/Editor/TrackWindowEditor.cs
@@ -226,18 +226,21 @@ public class TrackWindowEditor : EditorWindow
             usableEnd = usableStart;
 
         float usableLength = usableEnd - usableStart;
-        if (usableLength <= 0.01f)
+        float minSingleLength = Mathf.Max(0.01f, spacing * 0.25f);
+        if (usableLength <= minSingleLength)
         {
-            float distance = Mathf.Clamp(usableStart, 0f, totalLen);
-            placements.Add(CreatePlacement(s, distance));
+            float singleDistance = Mathf.Clamp(usableStart, 0f, totalLen);
+            placements.Add(CreatePlacement(s, singleDistance));
             return placements;
         }
 
-        int steps = Mathf.Max(1, Mathf.FloorToInt(usableLength / spacing) + 1);
+        int segmentCount = Mathf.Max(1, Mathf.RoundToInt(usableLength / spacing));
+        int placementCount = Mathf.Clamp(segmentCount + 1, 2, 100000);
 
-        for (int i = 0; i < steps; i++)
+        for (int i = 0; i < placementCount; i++)
         {
-            float distance = Mathf.Min(usableStart + i * spacing, usableEnd);
+            float t = placementCount > 1 ? i / (float)(placementCount - 1) : 0f;
+            float distance = Mathf.Lerp(usableStart, usableEnd, t);
             placements.Add(CreatePlacement(s, distance));
         }
 


### PR DESCRIPTION
## Summary
- add a live update toggle that watches spline and placement settings to rebuild prefabs automatically
- reuse previously generated pieces instead of re-instantiating on every rebuild and clean up extras
- track the last build settings and spline hash so changes trigger regeneration, and extend EditorUtil helpers

## Testing
- not run (Unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf3123a4d8832d8bbf73a444abb60c